### PR TITLE
Bug fixes:

### DIFF
--- a/providers/provider.go
+++ b/providers/provider.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/Sirupsen/logrus"
 	"os"
+	"strings"
 )
 
 var (
@@ -34,6 +35,11 @@ func init() {
 	if len(name) == 0 {
 		logrus.Fatalf("ROOT_DOMAIN is not set")
 	}
+
+	if !strings.HasSuffix(name, ".") {
+		name = name + "."
+	}
+
 	RootDomainName = name
 }
 

--- a/providers/route53.go
+++ b/providers/route53.go
@@ -69,13 +69,7 @@ func setHostedZone() error {
 		}
 	}
 	if hostedZone == nil {
-		logrus.Infof("Creating missing hosting zone for root domain %s ", RootDomainName)
-		req := route53.CreateHostedZoneRequest{Name: RootDomainName, Comment: "Updated by Rancher"}
-		resp, err := client.CreateHostedZone(&req)
-		if err != nil {
-			return fmt.Errorf("Failed to add missing hosted zone %v", err)
-		}
-		hostedZone = &resp.HostedZone
+		logrus.Fatalf("Hosted zone is missing for root domain %s ", RootDomainName)
 	}
 	return nil
 }


### PR DESCRIPTION
* don't create hosted zone if missing. The zone has to be precreated
* append "." at the end of the hosted zone name as thats the format
* route53 uses