### PR TITLE
Changes to avoid removing user added aws Route53 records

### DIFF
--- a/external-dns.go
+++ b/external-dns.go
@@ -133,9 +133,9 @@ func getProviderDnsRecords() (map[string]dns.DnsRecord, error) {
 	}
 	ourRecords := make(map[string]dns.DnsRecord, len(allRecords))
 	joins := []string{m.EnvironmentName, dns.RootDomainName}
-	suffix := strings.ToLower(strings.Join(joins, "."))
+	suffix := "." + strings.ToLower(strings.Join(joins, "."))
 	for _, value := range allRecords {
-		if strings.HasSuffix(value.Fqdn, suffix) {
+		if value.Type == "A" && strings.HasSuffix(value.Fqdn, suffix) && value.TTL == dns.TTL {
 			ourRecords[value.Fqdn] = value
 		}
 	}


### PR DESCRIPTION
We are going to apply following fix for now - remove only records that:

1) Only Type "A" records
2) that end with *.envName.domain.com - with . prepended
3) and having TTL = TTL defined on the template
And TTL on the template will be changed to non-trivial 299. That fix
should cover the majority of the user cases.

https://github.com/rancher/rancher/issues/3716

Tested manually.