### PR TITLE
Godeps update for crackcomm/cloudflare

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,7 @@
 {
 	"ImportPath": "github.com/rancher/external-dns",
 	"GoVersion": "go1.5.1",
+	"GodepVersion": "v62",
 	"Deps": [
 		{
 			"ImportPath": "github.com/Sirupsen/logrus",
@@ -14,7 +15,7 @@
 		},
 		{
 			"ImportPath": "github.com/crackcomm/cloudflare",
-			"Rev": "fddeb905945baf3fd946a5fdfa80eb66e7ad363f"
+			"Rev": "a60ec0b4c5e4c44b522040a54293f7f93cf5b887"
 		},
 		{
 			"ImportPath": "github.com/gorilla/context",

--- a/Godeps/_workspace/src/github.com/crackcomm/cloudflare/.gitignore
+++ b/Godeps/_workspace/src/github.com/crackcomm/cloudflare/.gitignore
@@ -22,3 +22,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+dist/

--- a/Godeps/_workspace/src/github.com/crackcomm/cloudflare/Dockerfile
+++ b/Godeps/_workspace/src/github.com/crackcomm/cloudflare/Dockerfile
@@ -1,0 +1,4 @@
+FROM busybox
+MAINTAINER Łukasz Kurowski <crackcomm@gmail.com>
+COPY ./dist/cf /cf
+ENTRYPOINT ["/cf"]

--- a/Godeps/_workspace/src/github.com/crackcomm/cloudflare/Makefile
+++ b/Godeps/_workspace/src/github.com/crackcomm/cloudflare/Makefile
@@ -1,0 +1,15 @@
+
+save-godeps:
+	godep save github.com/crackcomm/cloudflare/cf
+
+cloudflare-build:
+	mkdir -p dist
+	CGO_ENABLED=0 GOOS=linux go build -ldflags "-s" -a -installsuffix cgo -o ./dist/cf ./cf/main.go
+
+install:
+	go install github.com/crackcomm/cloudflare/cf
+
+dist: cloudflare-build
+
+clean:
+	rm -rf dist

--- a/Godeps/_workspace/src/github.com/crackcomm/cloudflare/README.md
+++ b/Godeps/_workspace/src/github.com/crackcomm/cloudflare/README.md
@@ -1,6 +1,7 @@
 # Golang CloudFlare® API v4 client
 
-[![GoDoc](https://godoc.org/github.com/crackcomm/cloudflare?status.svg)](https://godoc.org/github.com/crackcomm/cloudflare)
+[![GoDoc](https://godoc.org/github.com/crackcomm/cloudflare?status.svg)](https://godoc.org/github.com/crackcomm/cloudflare) [![Circle CI](https://img.shields.io/circleci/project/crackcomm/cloudflare.svg)](https://circleci.com/gh/crackcomm/cloudflare)
+
 
 Golang API Client for CloudFlare® API v4.
 
@@ -68,7 +69,7 @@ func main() {
 	})
 
 	ctx := context.Background()
-	ctx, _ = context.WithDeadline(ctx, time.Now().Add(time.Second*30))
+	ctx, _ = context.WithTimeout(ctx, time.Second*30)
 
 	zones, err := client.Zones.List(ctx)
 	if err != nil {

--- a/Godeps/_workspace/src/github.com/crackcomm/cloudflare/circle.yml
+++ b/Godeps/_workspace/src/github.com/crackcomm/cloudflare/circle.yml
@@ -1,0 +1,14 @@
+
+machine:
+  services:
+    - docker
+
+deployment:
+  staging:
+    branch: master
+    commands:
+      - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+      - make dist
+      - docker build -t crackcomm/cf:latest .
+      - docker push crackcomm/cf:latest
+      - make clean

--- a/Godeps/_workspace/src/github.com/crackcomm/cloudflare/client.go
+++ b/Godeps/_workspace/src/github.com/crackcomm/cloudflare/client.go
@@ -9,14 +9,16 @@ type Options struct {
 type Client struct {
 	*Zones
 	*Records
+	*Firewalls
 	opts *Options
 }
 
 // New - Creates a new Cloudflare client.
 func New(opts *Options) *Client {
 	return &Client{
-		Zones:   &Zones{opts: opts},
-		Records: &Records{opts: opts},
-		opts:    opts,
+		Zones:     &Zones{opts: opts},
+		Records:   &Records{opts: opts},
+		Firewalls: &Firewalls{opts: opts},
+		opts:      opts,
 	}
 }

--- a/Godeps/_workspace/src/github.com/crackcomm/cloudflare/client_firewalls.go
+++ b/Godeps/_workspace/src/github.com/crackcomm/cloudflare/client_firewalls.go
@@ -1,0 +1,75 @@
+package cloudflare
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"golang.org/x/net/context"
+)
+
+// Firewalls - Cloudflare Fireall Zones API Client.
+type Firewalls struct {
+	opts *Options
+}
+
+// Create - Creates a firewall rule for zone.
+func (firewalls *Firewalls) Create(ctx context.Context, id string, firewall *Firewall) (fw *Firewall, err error) {
+	buffer := new(bytes.Buffer)
+	err = json.NewEncoder(buffer).Encode(firewall)
+	if err != nil {
+		return
+	}
+	response, err := httpDo(ctx, firewalls.opts, "POST", apiURL("/zones/%s/firewall/access_rules/rules", id), buffer)
+	if err != nil {
+		return
+	}
+	defer response.Body.Close()
+	result, err := readResponse(response.Body)
+	if err != nil {
+		return
+	}
+	fw = new(Firewall)
+	err = json.Unmarshal(result.Result, &fw)
+	return
+}
+
+// List - Lists all firewall rules for zone.
+func (firewalls *Firewalls) List(ctx context.Context, zone string) ([]*Firewall, error) {
+	return firewalls.listPages(ctx, zone, 1)
+}
+
+// Delete - Deletes firewall by id.
+func (firewalls *Firewalls) Delete(ctx context.Context, zone, id string) (err error) {
+	response, err := httpDo(ctx, firewalls.opts, "DELETE", apiURL("/zones/%s/firewall/access_rules/rules/%s", zone, id), nil)
+	if err != nil {
+		return
+	}
+	defer response.Body.Close()
+	_, err = readResponse(response.Body)
+	return
+}
+
+// listPages - Gets all pages starting from `page`.
+func (firewalls *Firewalls) listPages(ctx context.Context, zone string, page int) (list []*Firewall, err error) {
+	response, err := httpDo(ctx, firewalls.opts, "GET", apiURL("/zones/%s/firewall/access_rules/rules?page=%d&per_page=50", zone, page), nil)
+	if err != nil {
+		return
+	}
+	defer response.Body.Close()
+	result, err := readResponse(response.Body)
+	if err != nil {
+		return
+	}
+	err = json.Unmarshal(result.Result, &list)
+	if err != nil {
+		return
+	}
+	if result.ResultInfo == nil || page >= result.ResultInfo.TotalPages {
+		return
+	}
+	next, err := firewalls.listPages(ctx, zone, page+1)
+	if err != nil {
+		return
+	}
+	return append(list, next...), nil
+}

--- a/Godeps/_workspace/src/github.com/crackcomm/cloudflare/client_firewalls_test.go
+++ b/Godeps/_workspace/src/github.com/crackcomm/cloudflare/client_firewalls_test.go
@@ -6,8 +6,8 @@ import (
 	"golang.org/x/net/context"
 )
 
-// ExampleRecords_List - Lists all zone DNS records.
-func ExampleRecords_List(ctx context.Context, client *Client) {
+// ExampleFirewalls_List - Lists all firewall rules for a zone.
+func ExampleFirewalls_List(ctx context.Context, client *Client) {
 	zones, err := client.Zones.List(ctx)
 	if err != nil {
 		log.Fatal(err)
@@ -15,12 +15,12 @@ func ExampleRecords_List(ctx context.Context, client *Client) {
 		log.Fatal("No zones were found")
 	}
 
-	records, err := client.Records.List(ctx, zones[0].ID)
+	rules, err := client.Firewalls.List(ctx, zones[0].ID)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	for _, record := range records {
-		log.Printf("%#v", record)
+	for _, rule := range rules {
+		log.Printf("%#v", rule)
 	}
 }

--- a/Godeps/_workspace/src/github.com/crackcomm/cloudflare/client_zones_test.go
+++ b/Godeps/_workspace/src/github.com/crackcomm/cloudflare/client_zones_test.go
@@ -6,8 +6,8 @@ import (
 	"golang.org/x/net/context"
 )
 
-// ExampleZonesList - Lists all zones.
-func ExampleZonesList(ctx context.Context, client *Client) {
+// ExampleZones_List - Lists all zones.
+func ExampleZones_List(ctx context.Context, client *Client) {
 	zones, err := client.Zones.List(ctx)
 	if err != nil {
 		log.Fatal(err)
@@ -18,8 +18,8 @@ func ExampleZonesList(ctx context.Context, client *Client) {
 	}
 }
 
-// ExampleZoneDetails - Gets zone details by ID.
-func ExampleZoneDetails(ctx context.Context, client *Client) {
+// ExampleZones_Details - Gets zone details by ID.
+func ExampleZones_Details(ctx context.Context, client *Client) {
 	zones, err := client.Zones.List(ctx)
 	if err != nil {
 		log.Fatal(err)
@@ -35,8 +35,8 @@ func ExampleZoneDetails(ctx context.Context, client *Client) {
 	log.Printf("Got %s = %#v", zones[0].ID, zone)
 }
 
-// ExampleZoneDelete - Deletes zone by ID.
-func ExampleZoneDelete(ctx context.Context, client *Client) {
+// ExampleZones_Delete - Deletes zone by ID.
+func ExampleZones_Delete(ctx context.Context, client *Client) {
 	zones, err := client.Zones.List(ctx)
 	if err != nil {
 		log.Fatal(err)

--- a/Godeps/_workspace/src/github.com/crackcomm/cloudflare/messages_firewalls.go
+++ b/Godeps/_workspace/src/github.com/crackcomm/cloudflare/messages_firewalls.go
@@ -1,0 +1,25 @@
+package cloudflare
+
+import (
+	"time"
+)
+
+type FirewallConfiguration struct {
+	Target string `json:"target,omitempty"`
+	Value  string `json:"value,omitempty"`
+}
+
+// Firewall - Firewall for zone.
+type Firewall struct {
+	ID string `json:"id,omitempty"`
+
+	Notes        string   `json:"notes,omitempty"`
+	AllowedModes []string `json:"allowed_modes,omitempty"`
+	Mode         string   `json:"mode,omitempty"`
+
+	Configuration *FirewallConfiguration `json:"configuration,omitempty"`
+	Scope         *ZoneOwner             `json:"scope,omitempty"`
+
+	CreatedOn  time.Time `json:"created_on,omitempty"`
+	ModifiedOn time.Time `json:"modified_on,omitempty"`
+}

--- a/Godeps/_workspace/src/github.com/crackcomm/cloudflare/messages_records.go
+++ b/Godeps/_workspace/src/github.com/crackcomm/cloudflare/messages_records.go
@@ -13,7 +13,8 @@ type Record struct {
 	Proxied   bool `json:"proxied,omitempty"`
 	Locked    bool `json:"locked,omitempty"`
 
-	TTL int `json:"ttl,omitempty"`
+	TTL      int `json:"ttl,omitempty"`
+	Priority int `json:"priority,omitempty"`
 
 	CreatedOn  time.Time `json:"created_on,omitempty"`
 	ModifiedOn time.Time `json:"modified_on,omitempty"`


### PR DESCRIPTION
Fixes rancher/rancher#4482
I didn't test out in a full rancher context, but locally it doesn't complain when registering my CloudFlare domain.
```bash
$ ./bin/external-dns
INFO[0000] Configured CloudFlare with zone "poxy.fr"
INFO[0000] DNSIMPLE_TOKEN is not set, skipping init of DNSimple provider
INFO[0000] GANDI_APIKEY is not set, skipping init of Gandi provider
INFO[0000] POINTHQ_TOKEN is not set, skipping init of PointHQ provider
FATA[0032] Failed to configure rancher-metadata: Error 403 accessing /version path
```