### PR TITLE
route53: Fix nil-pointer exception with alias resource records

### DIFF
--- a/providers/route53.go
+++ b/providers/route53.go
@@ -159,6 +159,10 @@ func (r *Route53Handler) GetRecords() ([]dns.DnsRecord, error) {
 	}
 
 	for _, rrSet := range rrSets {
+		// skip proprietary Route 53 alias resource record sets
+		if rrSet.AliasTarget != nil {
+			continue
+		}
 		records := []string{}
 		for _, rr := range rrSet.ResourceRecords {
 			records = append(records, *rr.Value)


### PR DESCRIPTION
Fixes https://github.com/rancher/rancher/issues/4671

To verify bug fix:
1. Create a new alias record set in a Route 53 hosted zone (ie 'A' record pointing to S3 website bucket) 
2. Launch Route53 DNS catalog service using the hosted zone
Expected: Service should start successfully