### PR TITLE
Cache error state of last provider call for health check

### DIFF
--- a/external-dns.go
+++ b/external-dns.go
@@ -41,29 +41,31 @@ func addMissingRecords(metadataRecs map[string]dns.DnsRecord, providerRecs map[s
 
 func updateRecords(toChange []dns.DnsRecord, op *Op) []dns.DnsRecord {
 	var changed []dns.DnsRecord
+	var err error
 	for _, value := range toChange {
 		switch *op {
 		case Add:
 			logrus.Infof("Adding dns record: %v", value)
-			if err := provider.AddRecord(value); err != nil {
+			if err = provider.AddRecord(value); err != nil {
 				logrus.Errorf("Failed to add DNS record to provider %v: %v", value, err)
 			} else {
 				changed = append(changed, value)
 			}
 		case Remove:
 			logrus.Infof("Removing dns record: %v", value)
-			if err := provider.RemoveRecord(value); err != nil {
+			if err = provider.RemoveRecord(value); err != nil {
 				logrus.Errorf("Failed to remove DNS record from provider %v: %v", value, err)
 			}
 		case Update:
 			logrus.Infof("Updating dns record: %v", value)
-			if err := provider.UpdateRecord(value); err != nil {
+			if err = provider.UpdateRecord(value); err != nil {
 				logrus.Errorf("Failed to update DNS record to provider %v: %v", value, err)
 			} else {
 				changed = append(changed, value)
 			}
 		}
 	}
+	checkProviderError(err)
 	return changed
 }
 
@@ -128,6 +130,7 @@ func removeExtraRecords(metadataRecs map[string]dns.DnsRecord, providerRecs map[
 
 func getProviderDnsRecords() (map[string]dns.DnsRecord, error) {
 	allRecords, err := provider.GetRecords()
+	checkProviderError(err)
 	if err != nil {
 		return nil, err
 	}

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -4,12 +4,26 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/gorilla/mux"
 	"net/http"
+	"sync"
 )
 
 var (
 	router         = mux.NewRouter()
 	healtcheckPort = ":1000"
+
+	providerErrored bool
+	stateLock       sync.Mutex
 )
+
+func checkProviderError(err error) {
+	stateLock.Lock()
+	if err != nil {
+		providerErrored = true
+	} else {
+		providerErrored = false
+	}
+	stateLock.Unlock()
+}
 
 func startHealthcheck() {
 	router.HandleFunc("/", healtcheck).Methods("GET", "HEAD").Name("Healthcheck")
@@ -24,11 +38,13 @@ func healtcheck(w http.ResponseWriter, req *http.Request) {
 		logrus.Error("Healtcheck failed: unable to reach metadata")
 		http.Error(w, "Failed to reach metadata server", http.StatusInternalServerError)
 	} else {
-		// 2) test provider
-		_, err := provider.GetRecords()
-		if err != nil {
-			logrus.Error("Healtcheck failed: unable to reach a provider")
-			http.Error(w, "Failed to reach an external provider ", http.StatusInternalServerError)
+		// 2) check last error value from provider method call
+		stateLock.Lock()
+		errored := providerErrored
+		stateLock.Unlock()
+		if errored {
+			logrus.Error("Healtcheck failed: last call to provider failed")
+			http.Error(w, "Last call to provider failed", http.StatusInternalServerError)
 		} else {
 			err := c.TestConnect()
 			if err != nil {


### PR DESCRIPTION
Calling the provider API in the health check intervals results in a steady high overall request rate for which most DNS API's are not designed for. DNSimple has reported to us that some of their customers using Rancher send up to 6000 calls/hour just from health checks (probably due to several environments). Route 53 imposes account wide 5 req/sec limit from which the health check consumes already 50% when running the DNS stacks in 5 environments.
