### PR TITLE
added fqdn separator env variable

### DIFF
--- a/dns/dns.go
+++ b/dns/dns.go
@@ -10,6 +10,7 @@ import (
 var (
 	RootDomainName string
 	TTL            int
+	fqdnSeparator  string
 )
 
 type DnsRecord struct {
@@ -30,6 +31,10 @@ func init() {
 	name = os.Getenv("ROOT_DOMAIN")
 	if len(name) == 0 {
 		logrus.Fatalf("ROOT_DOMAIN is not set")
+	}
+	fqdnSeparator = os.Getenv("FQDN_SEPARATOR")
+	if len(fqdnSeparator) == 0 {
+		fqdnSeparator = "."
 	}
 	TTLEnv := os.Getenv("TTL")
 	i, err := strconv.Atoi(TTLEnv)
@@ -53,6 +58,6 @@ func ConvertToServiceDnsRecord(dnsRecord DnsRecord) ServiceDnsRecord {
 }
 
 func ConvertToFqdn(serviceName string, stackName string, environmentName string) string {
-	domainNameEntries := []string{serviceName, stackName, environmentName, RootDomainName}
-	return strings.ToLower(strings.Join(domainNameEntries, "."))
+	domainNameEntries := []string{serviceName, stackName, environmentName}
+	return strings.ToLower(strings.Join(domainNameEntries, fqdnSeparator) + "." + RootDomainName)
 }


### PR DESCRIPTION
Allows the <service>.<stack>.<env> part of fqdn to be seprated by other char that a dot.
I use it with wildcard ssl certificates that allows only one level of subdomains.
You must set the env variable FQDN_SEPARATOR to the char (or chars) you want to use between service, stack and env names.