### PR TITLE
Prevent provider API flooding + smaller fixes

### DIFF
--- a/healthcheck.go
+++ b/healthcheck.go
@@ -27,7 +27,7 @@ func healtcheck(w http.ResponseWriter, req *http.Request) {
 		// 2) test provider
 		err := provider.HealthCheck()
 		if err != nil {
-			logrus.Error("Healtcheck failed: Error from provider: %v", err)
+			logrus.Errorf("Healtcheck failed: Error from provider: %v", err)
 			http.Error(w, "Failed to reach an external provider ", http.StatusInternalServerError)
 		} else {
 			err := c.TestConnect()

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -125,7 +125,6 @@ func addToDnsEntries(dnsEntry utils.DnsRecord, dnsEntries map[string]utils.DnsRe
 
 func containerStateOK(container metadata.Container) bool {
 	switch container.State {
-	case "starting":
 	case "running":
 	default:
 		return false


### PR DESCRIPTION
* Check if metadata records have changed before querying provider
* Only include containers whose state is ‚running’
* Fix error call formatting

Tested with Route53