### PR TITLE
Build static binary with Go internal linker

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -6,5 +6,4 @@ source $(dirname $0)/version
 cd $(dirname $0)/..
 
 mkdir -p bin
-[ "$(uname)" != "Darwin" ] && LINKFLAGS="-linkmode external -extldflags -static -s"
-go build -ldflags "-X main.Version=$VERSION $LINKFLAGS" -o bin/external-dns
+CGO_ENABLED=0 go build -ldflags "-X main.Version=$VERSION -s" -o bin/external-dns


### PR DESCRIPTION
Static linking with gcc may cause segfaults at runtime on some systems:
* https://github.com/rancher/rancher/issues/6111
* https://github.com/golang/go/issues/13470