### PR TITLE
Allow overriding name template for specific services by setting io.rancher.service.external_dns_name_template label to it in docker-compose.yml

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -145,7 +145,6 @@ func (m *MetadataClient) getContainersDnsRecords(dnsEntries map[string]utils.Dns
 				logrus.Errorf("Skipping container %s: Invalid IP address %s", container.Name, externalIP)
 			}
 
-			var nameTemplate string
 			nameTemplate, ok := service.Labels["io.rancher.service.external_dns_name_template"]
 			if !ok {
 				nameTemplate = config.NameTemplate

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -145,7 +145,13 @@ func (m *MetadataClient) getContainersDnsRecords(dnsEntries map[string]utils.Dns
 				logrus.Errorf("Skipping container %s: Invalid IP address %s", container.Name, externalIP)
 			}
 
-			fqdn := utils.FqdnFromTemplate(config.NameTemplate, container.ServiceName, container.StackName,
+			var nameTemplate string
+			nameTemplate, ok := service.Labels["io.rancher.service.external_dns_name_template"]
+			if !ok {
+				nameTemplate = config.NameTemplate
+			}
+
+			fqdn := utils.FqdnFromTemplate(nameTemplate, container.ServiceName, container.StackName,
 				m.EnvironmentName, config.RootDomainName)
 
 			addToDnsEntries(fqdn, externalIP, dnsEntries)


### PR DESCRIPTION
Allow overriding name template for specific services by setting io.rancher.service.external_dns_name_template label to it in docker-compose.yml