### PR TITLE
Fixes Cattle FQDN updates with custom name templates

### DIFF
--- a/cattle.go
+++ b/cattle.go
@@ -25,13 +25,13 @@ func NewCattleClient(cattleUrl string, accessKey string, secretKey string) (*Cat
 	}, nil
 }
 
-func (c *CattleClient) UpdateServiceDomainName(serviceDnsRecord utils.ServiceDnsRecord) error {
+func (c *CattleClient) UpdateServiceDomainName(metadataRecord utils.MetadataDnsRecord) error {
 	event := &rancher.ExternalDnsEvent{
 		EventType:   "dns.update",
-		ExternalId:  serviceDnsRecord.Fqdn,
-		ServiceName: serviceDnsRecord.ServiceName,
-		StackName:   serviceDnsRecord.StackName,
-		Fqdn:        serviceDnsRecord.Fqdn,
+		ExternalId:  metadataRecord.DnsRecord.Fqdn,
+		ServiceName: metadataRecord.ServiceName,
+		StackName:   metadataRecord.StackName,
+		Fqdn:        utils.UnFqdn(metadataRecord.DnsRecord.Fqdn),
 	}
 	_, err := c.rancherClient.ExternalDnsEvent.Create(event)
 	return err

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,6 +1,8 @@
-FROM alpine:3.4
-MAINTAINER Rancher Labs, Inc.
-RUN apk add --no-cache ca-certificates openssl bash
+FROM alpine:3.5
+LABEL maintainer "Rancher Labs, Inc."
+
+RUN apk upgrade --no-cache && \
+    apk add --no-cache ca-certificates openssl bash
 
 ENV SSL_SCRIPT_COMMIT 08278ace626ada71384fc949bd637f4c15b03b53
 RUN wget -O /usr/bin/update-rancher-ssl https://raw.githubusercontent.com/rancher/rancher/${SSL_SCRIPT_COMMIT}/server/bin/update-rancher-ssl && \

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -15,23 +15,21 @@ const (
 	stateRecordFqdnTemplate = "external-dns-%s.%s"
 )
 
+// MetadataDnsRecord is a wrapper around a DnsRecord
+// that holds information about the service and stack
+// the record belongs to
+type MetadataDnsRecord struct {
+	ServiceName string
+	StackName   string
+	DnsRecord   DnsRecord
+}
+
+// DnsRecord represents a provider DNS record
 type DnsRecord struct {
 	Fqdn    string
 	Records []string
 	Type    string
 	TTL     int
-}
-
-type ServiceDnsRecord struct {
-	Fqdn        string
-	ServiceName string
-	StackName   string
-}
-
-func ConvertToServiceDnsRecord(dnsRecord DnsRecord) ServiceDnsRecord {
-	splitted := strings.Split(dnsRecord.Fqdn, ".")
-	serviceRecord := ServiceDnsRecord{dnsRecord.Fqdn, splitted[0], splitted[1]}
-	return serviceRecord
 }
 
 // Fqdn ensures that the name is a fqdn adding a trailing dot if necessary.


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/8641

Updating the cattle FQDN service property requires specifying the stack and service names.
And because we now allow custom name templates we can't derive the service/stack names by string parsing the FQDN of the DNS record after it was created. Main change here is to add a `MetadataDnsRecord` type that wraps a `DnsRecord` with the stack/service name it is created for. 