### PR TITLE
Switch DNSimple provider to API v2

### DIFF
--- a/providers/dnsimple/dnsimple.go
+++ b/providers/dnsimple/dnsimple.go
@@ -82,14 +82,14 @@ func (d *DNSimpleProvider) parseName(record utils.DnsRecord) string {
 func (d *DNSimpleProvider) AddRecord(record utils.DnsRecord) error {
 	name := d.parseName(record)
 	for _, rec := range record.Records {
-		recordInput := api.Record{
+		recordInput := dnsimple.ZoneRecord{
 			Name:    name,
 			TTL:     record.TTL,
 			Type:    record.Type,
 			Content: rec,
 		}
 		d.limiter.Wait(1)
-		_, _, err := d.client.Domains.CreateRecord(d.root, recordInput)
+		_, err := d.client2.Zones.CreateRecord(d.accountID, d.root, recordInput)
 		if err != nil {
 			return fmt.Errorf("DNSimple API call has failed: %v", err)
 		}

--- a/providers/dnsimple/dnsimple.go
+++ b/providers/dnsimple/dnsimple.go
@@ -134,7 +134,7 @@ func (d *DNSimpleProvider) RemoveRecord(record utils.DnsRecord) error {
 
 	for _, rec := range records {
 		d.limiter.Wait(1)
-		_, err := d.client.Domains.DeleteRecord(d.root, rec.Id)
+		_, err := d.client2.Zones.DeleteRecord(d.accountID, d.root, rec.Id)
 		if err != nil {
 			return fmt.Errorf("DNSimple API call has failed: %v", err)
 		}

--- a/providers/dnsimple/dnsimple.go
+++ b/providers/dnsimple/dnsimple.go
@@ -11,12 +11,10 @@ import (
 	"github.com/juju/ratelimit"
 	"github.com/rancher/external-dns/providers"
 	"github.com/rancher/external-dns/utils"
-	api "github.com/weppos/go-dnsimple/dnsimple"
 )
 
 type DNSimpleProvider struct {
-	client    *api.Client
-	client2   *dnsimple.Client
+	client    *dnsimple.Client
 	accountID string
 	root      string
 	limiter   *ratelimit.Bucket
@@ -27,14 +25,10 @@ func init() {
 }
 
 func (d *DNSimpleProvider) Init(rootDomainName string) error {
-	var email, apiToken, oauthToken string
+	var oauthToken string
 
-	if email = os.Getenv("DNSIMPLE_EMAIL"); len(email) == 0 {
-		return fmt.Errorf("DNSIMPLE_EMAIL is not set")
-	}
-
-	if apiToken = os.Getenv("DNSIMPLE_TOKEN"); len(apiToken) == 0 {
-		return fmt.Errorf("DNSIMPLE_TOKEN is not set")
+	if len(os.Getenv("DNSIMPLE_EMAIL")) > 0 {
+		return fmt.Errorf("DNSimple API v2 requires an account identifier and the new OAuth token. Please upgrade your configuration.")
 	}
 
 	if oauthToken = os.Getenv("DNSIMPLE_TOKEN"); len(oauthToken) == 0 {
@@ -42,11 +36,10 @@ func (d *DNSimpleProvider) Init(rootDomainName string) error {
 	}
 
 	d.root = utils.UnFqdn(rootDomainName)
-	d.client = api.NewClient(apiToken, email)
-	d.client2 = dnsimple.NewClient(dnsimple.NewOauthTokenCredentials(oauthToken))
+	d.client = dnsimple.NewClient(dnsimple.NewOauthTokenCredentials(oauthToken))
 	d.limiter = ratelimit.NewBucketWithRate(1.5, 5)
 
-	whoamiResponse, err := d.client2.Identity.Whoami()
+	whoamiResponse, err := d.client.Identity.Whoami()
 	if err != nil {
 		return fmt.Errorf("DNSimple Authentication failed: %v", err)
 	}
@@ -55,7 +48,7 @@ func (d *DNSimpleProvider) Init(rootDomainName string) error {
 	}
 	d.accountID = strconv.Itoa(whoamiResponse.Data.Account.ID)
 
-	_, err = d.client2.Zones.GetZone(d.accountID, d.root)
+	_, err = d.client.Zones.GetZone(d.accountID, d.root)
 	if err != nil {
 		return fmt.Errorf("Failed to get zone for '%s': %v", d.root)
 	}
@@ -70,7 +63,7 @@ func (*DNSimpleProvider) GetName() string {
 
 func (d *DNSimpleProvider) HealthCheck() error {
 	d.limiter.Wait(1)
-	_, err := d.client2.Identity.Whoami()
+	_, err := d.client.Identity.Whoami()
 	return err
 }
 
@@ -89,7 +82,7 @@ func (d *DNSimpleProvider) AddRecord(record utils.DnsRecord) error {
 			Content: rec,
 		}
 		d.limiter.Wait(1)
-		_, err := d.client2.Zones.CreateRecord(d.accountID, d.root, recordInput)
+		_, err := d.client.Zones.CreateRecord(d.accountID, d.root, recordInput)
 		if err != nil {
 			return fmt.Errorf("DNSimple API call has failed: %v", err)
 		}
@@ -102,7 +95,7 @@ func (d *DNSimpleProvider) findRecords(record utils.DnsRecord) ([]dnsimple.ZoneR
 	var zoneRecords []dnsimple.ZoneRecord
 
 	d.limiter.Wait(1)
-	recordsResponse, err := d.client2.Zones.ListRecords(d.accountID, d.root, nil)
+	recordsResponse, err := d.client.Zones.ListRecords(d.accountID, d.root, nil)
 	if err != nil {
 		return zoneRecords, fmt.Errorf("DNSimple API call has failed: %v", err)
 	}
@@ -134,7 +127,7 @@ func (d *DNSimpleProvider) RemoveRecord(record utils.DnsRecord) error {
 
 	for _, zoneRecord := range zoneRecords {
 		d.limiter.Wait(1)
-		_, err := d.client2.Zones.DeleteRecord(d.accountID, d.root, zoneRecord.ID)
+		_, err := d.client.Zones.DeleteRecord(d.accountID, d.root, zoneRecord.ID)
 		if err != nil {
 			return fmt.Errorf("DNSimple API call has failed: %v", err)
 		}
@@ -147,7 +140,7 @@ func (d *DNSimpleProvider) GetRecords() ([]utils.DnsRecord, error) {
 	var records []utils.DnsRecord
 
 	d.limiter.Wait(1)
-	recordsResponse, err := d.client2.Zones.ListRecords(d.accountID, d.root, nil)
+	recordsResponse, err := d.client.Zones.ListRecords(d.accountID, d.root, nil)
 	if err != nil {
 		return records, fmt.Errorf("DNSimple API call has failed: %v", err)
 	}

--- a/providers/dnsimple/dnsimple.go
+++ b/providers/dnsimple/dnsimple.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/dnsimple/dnsimple-go/dnsimple"
 	"github.com/juju/ratelimit"
 	"github.com/rancher/external-dns/providers"
 	"github.com/rancher/external-dns/utils"
@@ -14,6 +15,7 @@ import (
 
 type DNSimpleProvider struct {
 	client  *api.Client
+	client2 *dnsimple.Client
 	root    string
 	limiter *ratelimit.Bucket
 }
@@ -23,7 +25,8 @@ func init() {
 }
 
 func (d *DNSimpleProvider) Init(rootDomainName string) error {
-	var email, apiToken string
+	var email, apiToken, oauthToken string
+
 	if email = os.Getenv("DNSIMPLE_EMAIL"); len(email) == 0 {
 		return fmt.Errorf("DNSIMPLE_EMAIL is not set")
 	}
@@ -32,8 +35,13 @@ func (d *DNSimpleProvider) Init(rootDomainName string) error {
 		return fmt.Errorf("DNSIMPLE_TOKEN is not set")
 	}
 
+	if oauthToken = os.Getenv("DNSIMPLE_TOKEN"); len(oauthToken) == 0 {
+		return fmt.Errorf("DNSIMPLE_TOKEN is not set")
+	}
+
 	d.root = utils.UnFqdn(rootDomainName)
 	d.client = api.NewClient(apiToken, email)
+	d.client2 = dnsimple.NewClient(dnsimple.NewOauthTokenCredentials(oauthToken))
 	d.limiter = ratelimit.NewBucketWithRate(1.5, 5)
 
 	domains, _, err := d.client.Domains.List()
@@ -63,7 +71,7 @@ func (*DNSimpleProvider) GetName() string {
 
 func (d *DNSimpleProvider) HealthCheck() error {
 	d.limiter.Wait(1)
-	_, _, err := d.client.Users.User()
+	_, err := d.client2.Identity.Whoami()
 	return err
 }
 

--- a/providers/dnsimple/dnsimple.go
+++ b/providers/dnsimple/dnsimple.go
@@ -3,6 +3,7 @@ package dnsimple
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/Sirupsen/logrus"
@@ -14,10 +15,11 @@ import (
 )
 
 type DNSimpleProvider struct {
-	client  *api.Client
-	client2 *dnsimple.Client
-	root    string
-	limiter *ratelimit.Bucket
+	client    *api.Client
+	client2   *dnsimple.Client
+	accountID string
+	root      string
+	limiter   *ratelimit.Bucket
 }
 
 func init() {
@@ -44,21 +46,18 @@ func (d *DNSimpleProvider) Init(rootDomainName string) error {
 	d.client2 = dnsimple.NewClient(dnsimple.NewOauthTokenCredentials(oauthToken))
 	d.limiter = ratelimit.NewBucketWithRate(1.5, 5)
 
-	domains, _, err := d.client.Domains.List()
+	whoamiResponse, err := d.client2.Identity.Whoami()
 	if err != nil {
-		return fmt.Errorf("Failed to list zones: %v", err)
+		return fmt.Errorf("DNSimple Authentication failed: %v", err)
 	}
-
-	found := false
-	for _, domain := range domains {
-		if domain.Name == d.root {
-			found = true
-			break
-		}
+	if whoamiResponse.Data.Account == nil {
+		return fmt.Errorf("DNSimple User tokens are not supported, use an Account token")
 	}
+	d.accountID = strconv.Itoa(whoamiResponse.Data.Account.ID)
 
-	if !found {
-		return fmt.Errorf("Zone for '%s' not found", d.root)
+	_, err = d.client2.Zones.GetZone(d.accountID, d.root)
+	if err != nil {
+		return fmt.Errorf("Failed to get zone for '%s': %v", d.root)
 	}
 
 	logrus.Infof("Configured %s with zone '%s'", d.GetName(), d.root)


### PR DESCRIPTION
This PR replaces the legacy API v1 provider with an API v2 provider.

DNSimple released API v2 in 2016 and we are now in the process of shutting down API v1.
https://blog.dnsimple.com/2016/12/api-v2-stable/

Inspecting our logs we determined a significant portion of API v1 requests are coming from Rancher users that are using an old v1 integration. All these users will be unable to connect to DNSimple once the API v1 will be disabled.

I tried to minimize the changes beyond what was required to integrate with API v2. There are actually some possible optimizations such as:

1. passing query options in findRecords to filter the returned record set
1. using our `UpdateRecord` method instead of removing/adding records

but I haven't made these changes yet as I didn't have any possibility to test this integration. In fact, testing was one of the major issues I had with this PR as this repo doesn't have any test file, nor CI integration.

Can you please provide instructions on how to properly test these changes and/or please test the PR to make sure it works as expected?

We would appreciate if you can ship these changes at your earliest convenience after we have confirmation the changes did not break the existing integration. Otherwise, Rancher users will be unable to use the integration as soon as API v1 access will be shut down.