### PR TITLE
Option: Use primary container IP

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -131,7 +131,9 @@ func (m *MetadataClient) getContainersDnsRecords(dnsEntries map[string]utils.Met
 			}
 
 			var externalIP string
-			if ip, ok := host.Labels["io.rancher.host.external_dns_ip"]; ok && len(ip) > 0 {
+			if label, ok := service.Labels["io.rancher.service.internal_ip_for_dns"]; ok && label == "true" {
+				externalIP = container.PrimaryIp
+			} else if ip, ok := host.Labels["io.rancher.host.external_dns_ip"]; ok && len(ip) > 0 {
 				externalIP = ip
 			} else if len(container.Ports) > 0 {
 				if ip, ok := parsePortToIP(container.Ports[0]); ok {


### PR DESCRIPTION
I've defined a new service label called "io.rancher.service.internal_ip_for_dns". If it's set and the value is "true" the dns record will created with the primary container IP. 

This is useful for environments where Flat Network or MACVLAN is in use.